### PR TITLE
A120 support soft delete only for stamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A microservice for managing the permissions of materials at Sanger. This is done through Stamps.
 
-A Stamp is a way of applying restrictions on samples. Only the owner of a particular sample can apply a Stamp to it. For example, if a stamp lists user "dr6" amoung its "spend" permissions, then any material thus stamped will have "dr6 can order work on me" permission.
+A Stamp is a way of applying restrictions on samples. Only the owner of a particular sample can apply a Stamp to it. For example, if a stamp lists user "dr6" amoung its "consume" permissions, then any material thus stamped will have "dr6 can order work on me" permission.
 
 A material can have multiple stamps applied to it, and gain new permissions from each of them.
 

--- a/app/controllers/api/v1/api_controller.rb
+++ b/app/controllers/api/v1/api_controller.rb
@@ -6,6 +6,9 @@ module Api
       rescue_from CanCan::AccessDenied do |exception|
         head :forbidden, content_type: 'application/vnd.api+json'
       end
+      rescue_from Errors::ResourceGone do |exception|
+        head :gone, content_type: 'application/vnd.api+json'
+      end
 
     private
 

--- a/app/lib/permission_checker.rb
+++ b/app/lib/permission_checker.rb
@@ -1,5 +1,3 @@
-require 'set'
-
 class PermissionChecker
 
   class << self
@@ -8,9 +6,9 @@ class PermissionChecker
     def check(permission_type, names, material_uuids)
       material_uuids = material_uuids.uniq
       @unpermitted_uuids = []
-      permitted_uuids = Set.new(select_permitted_material_uuids(permission_type, names, material_uuids))
+      permitted_uuids = select_permitted_material_uuids(permission_type, names, material_uuids)
 
-      @unpermitted_uuids = material_uuids.reject { |mu| permitted_uuids.include?(mu) }
+      @unpermitted_uuids = material_uuids - permitted_uuids
       return @unpermitted_uuids.empty?
     end
 

--- a/app/models/stamp.rb
+++ b/app/models/stamp.rb
@@ -5,4 +5,16 @@ class Stamp < ApplicationRecord
 
   validates :name, presence: true, uniqueness: true
   validates :owner_id, presence: true
+
+  def active?
+    deactivated_at.nil?
+  end
+
+  def deactivated?
+    !active?
+  end
+
+  def deactivate!
+    update_attributes!(deactivated_at: DateTime.now) if active?
+  end
 end

--- a/app/resources/api/v1/stamp_resource.rb
+++ b/app/resources/api/v1/stamp_resource.rb
@@ -6,9 +6,9 @@ module Api
       has_many :permissions, class_name: 'Permission', relation_name: :permissions
       has_many :materials, class_name: 'Material', relation_name: :stamp_materials
 
-      before_create do
-        @model.owner_id = context[:current_user].email
-      end
+      filter :activeness, default: "true", apply: -> (records, value, _options) {
+        (value[0].downcase == "true") ? records.where(deactivated_at: nil) : records.where.not(deactivated_at: nil)
+      }
 
       def self.updatable_fields(context)
         [:name]
@@ -17,10 +17,22 @@ module Api
         [:name]
       end
 
+      before_create do
+        @model.owner_id = context[:current_user].email
+      end
+
       before_update :authorize!
-      before_remove :authorize!
+
+      def remove
+        authorize!
+        @model.deactivate!
+        :completed
+      end
 
       def authorize!
+        if @model.deactivated?
+          raise Errors::ResourceGone
+        end
         if @model.owner_id != context[:current_user].email
           raise CanCan::AccessDenied
         end

--- a/config/application.rb
+++ b/config/application.rb
@@ -19,5 +19,7 @@ module AkerStamps
 
     config.accessible_id_type = :uuid
 
+    config.autoload_paths << Rails.root.join('lib')
+
   end
 end

--- a/config/initializers/jsonapi-resources.rb
+++ b/config/initializers/jsonapi-resources.rb
@@ -1,3 +1,3 @@
 JSONAPI.configure do |config|
-  config.exception_class_whitelist = [CanCan::AccessDenied]
+  config.exception_class_whitelist = [CanCan::AccessDenied, Errors::ResourceGone]
 end

--- a/db/migrate/20170802103010_add_deactivated_at_to_stamps.rb
+++ b/db/migrate/20170802103010_add_deactivated_at_to_stamps.rb
@@ -1,0 +1,5 @@
+class AddDeactivatedAtToStamps < ActiveRecord::Migration[5.0]
+  def change
+    add_column :stamps, :deactivated_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170721144531) do
+ActiveRecord::Schema.define(version: 20170802103010) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -39,10 +39,11 @@ ActiveRecord::Schema.define(version: 20170721144531) do
   end
 
   create_table "stamps", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
-    t.string   "name",       null: false
-    t.string   "owner_id",   null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.string   "name",           null: false
+    t.string   "owner_id",       null: false
+    t.datetime "created_at",     null: false
+    t.datetime "updated_at",     null: false
+    t.datetime "deactivated_at"
     t.index ["name"], name: "index_stamps_on_name", unique: true, using: :btree
   end
 

--- a/lib/errors.rb
+++ b/lib/errors.rb
@@ -1,0 +1,4 @@
+module Errors
+  class ResourceGone < StandardError
+  end
+end

--- a/spec/controllers/api/v1/permissions_controller_spec.rb
+++ b/spec/controllers/api/v1/permissions_controller_spec.rb
@@ -6,12 +6,12 @@ RSpec.describe Api::V1::PermissionsController, type: :controller do
       stamp = create(:stamp)
       sm = create(:stamp_material, stamp: stamp)
       @material_uuid = sm.material_uuid
-      stamp.permissions.create!(permission_type: :spend, permitted: 'mygroup')
+      stamp.permissions.create!(permission_type: :consume, permitted: 'mygroup')
     end
 
     context 'when the materials are permitted' do
       before do
-        post :check, params: { data: { permission_type: :spend, names: ['dirk', 'mygroup'], material_uuids: [@material_uuid] }  }
+        post :check, params: { data: { permission_type: :consume, names: ['dirk', 'mygroup'], material_uuids: [@material_uuid] }  }
       end
       it 'responds OK' do
         expect(response).to have_http_status(:ok)
@@ -21,7 +21,7 @@ RSpec.describe Api::V1::PermissionsController, type: :controller do
     context 'when some materials are not permitted' do
       before do
         @bad_uuid = SecureRandom.uuid
-        post :check, params: { data: { permission_type: :spend, names: ['dirk', 'mygroup'], material_uuids: [@material_uuid, @bad_uuid] }  }
+        post :check, params: { data: { permission_type: :consume, names: ['dirk', 'mygroup'], material_uuids: [@material_uuid, @bad_uuid] }  }
       end
       it 'responds forbidden' do
         expect(response).to have_http_status(:forbidden)

--- a/spec/controllers/api/v1/stamps_controller_spec.rb
+++ b/spec/controllers/api/v1/stamps_controller_spec.rb
@@ -23,14 +23,14 @@ RSpec.describe Api::V1::StampsController, type: :controller do
 
     let(:init_permissions) do
       [
-        { permission_type: :spend, permitted: 'alpha' },
-        { permission_type: :write, permitted: 'beta' },
+        { permission_type: :consume, permitted: 'alpha' },
+        { permission_type: :edit, permitted: 'beta' },
       ]
     end
 
     let(:permission_data) do
       [
-        { 'permission-type': :spend, permitted: 'omega' }
+        { 'permission-type': :consume, permitted: 'omega' }
       ]
     end
 
@@ -85,8 +85,8 @@ RSpec.describe Api::V1::StampsController, type: :controller do
 
       it 'does not update the stamp permissions' do
         initial_permissions = [
-          { 'permission-type': :spend, permitted: 'alpha' },
-          { 'permission-type': :write, permitted: 'beta' },
+          { 'permission-type': :consume, permitted: 'alpha' },
+          { 'permission-type': :edit, permitted: 'beta' },
         ]
         expect(result_permissions).to match_array(initial_permissions)
       end

--- a/spec/lib/permission_checker_spec.rb
+++ b/spec/lib/permission_checker_spec.rb
@@ -10,10 +10,10 @@ RSpec.describe PermissionChecker do
 
   describe '#check' do
     before do
-      @stamp1 = make_stamp('jeff', :write)
-      @stamp2 = make_stamp('beta', :write)
+      @stamp1 = make_stamp('jeff', :edit)
+      @stamp2 = make_stamp('beta', :edit)
       @stamp3 = make_stamp('jeff', :read)
-      @stamp4 = make_stamp('dirk', :write)
+      @stamp4 = make_stamp('dirk', :edit)
 
       @permitted_uuids = [@stamp1.stamp_materials.first.material_uuid, @stamp2.stamp_materials.first.material_uuid]
       @unpermitted_uuids = [@stamp3.stamp_materials.first.material_uuid, @stamp4.stamp_materials.first.material_uuid, SecureRandom.uuid]
@@ -22,22 +22,22 @@ RSpec.describe PermissionChecker do
 
     context 'when the materials are not all permitted' do
       it 'should return false' do
-        expect(PermissionChecker.check(:write, ['alpha', 'beta', 'jeff'], @material_uuids)).to eq(false)
+        expect(PermissionChecker.check(:edit, ['alpha', 'beta', 'jeff'], @material_uuids)).to eq(false)
       end
 
       it 'should put the unpermitted materials into the unpermitted_uuids attribute' do
-        PermissionChecker.check(:write, ['alpha', 'beta', 'jeff'], @material_uuids)
+        PermissionChecker.check(:edit, ['alpha', 'beta', 'jeff'], @material_uuids)
         expect(PermissionChecker.unpermitted_uuids).to eq(@unpermitted_uuids)
       end
     end
 
     context 'when the materials are all permitted' do
       it 'should return false' do
-        expect(PermissionChecker.check(:write, ['alpha', 'beta', 'jeff'], @permitted_uuids)).to eq(true)
+        expect(PermissionChecker.check(:edit, ['alpha', 'beta', 'jeff'], @permitted_uuids)).to eq(true)
       end
 
       it 'should have an empty unpermitted_uuids attribute' do
-        PermissionChecker.check(:write, ['alpha', 'beta', 'jeff'], @permitted_uuids)
+        PermissionChecker.check(:edit, ['alpha', 'beta', 'jeff'], @permitted_uuids)
         expect(PermissionChecker.unpermitted_uuids).to be_empty
       end
     end
@@ -50,11 +50,11 @@ RSpec.describe PermissionChecker do
       end
 
       it 'should return false' do
-        expect(PermissionChecker.check(:write, ['alpha', 'beta', 'jeff'], @material_uuids)).to eq(false)
+        expect(PermissionChecker.check(:edit, ['alpha', 'beta', 'jeff'], @material_uuids)).to eq(false)
       end
 
       it 'should put the unpermitted materials into the unpermitted_uuids attribute' do
-        PermissionChecker.check(:write, ['alpha', 'beta', 'jeff'], @material_uuids)
+        PermissionChecker.check(:edit, ['alpha', 'beta', 'jeff'], @material_uuids)
         expect(PermissionChecker.unpermitted_uuids).to eq(@unpermitted_uuids)
       end
     end

--- a/spec/lib/permission_checker_spec.rb
+++ b/spec/lib/permission_checker_spec.rb
@@ -9,12 +9,12 @@ RSpec.describe PermissionChecker do
   end
 
   describe '#check' do
-
     before do
       @stamp1 = make_stamp('jeff', :write)
       @stamp2 = make_stamp('beta', :write)
       @stamp3 = make_stamp('jeff', :read)
       @stamp4 = make_stamp('dirk', :write)
+
       @permitted_uuids = [@stamp1.stamp_materials.first.material_uuid, @stamp2.stamp_materials.first.material_uuid]
       @unpermitted_uuids = [@stamp3.stamp_materials.first.material_uuid, @stamp4.stamp_materials.first.material_uuid, SecureRandom.uuid]
       @material_uuids = @permitted_uuids + @unpermitted_uuids
@@ -39,6 +39,23 @@ RSpec.describe PermissionChecker do
       it 'should have an empty unpermitted_uuids attribute' do
         PermissionChecker.check(:write, ['alpha', 'beta', 'jeff'], @permitted_uuids)
         expect(PermissionChecker.unpermitted_uuids).to be_empty
+      end
+    end
+
+    context 'when the stamp is deactivated' do
+      before do
+        @stamp1.deactivate!
+        @unpermitted_uuids = [@stamp1.stamp_materials.first.material_uuid]
+        @material_uuids = @permitted_uuids
+      end
+
+      it 'should return false' do
+        expect(PermissionChecker.check(:write, ['alpha', 'beta', 'jeff'], @material_uuids)).to eq(false)
+      end
+
+      it 'should put the unpermitted materials into the unpermitted_uuids attribute' do
+        PermissionChecker.check(:write, ['alpha', 'beta', 'jeff'], @material_uuids)
+        expect(PermissionChecker.unpermitted_uuids).to eq(@unpermitted_uuids)
       end
     end
 

--- a/spec/models/stamp_spec.rb
+++ b/spec/models/stamp_spec.rb
@@ -38,4 +38,27 @@ RSpec.describe Stamp, type: :model do
       expect(StampMaterial.where(id: @mat.id).first).to be_nil
     end
   end
+
+  describe '#deactivate!' do
+    it 'works' do
+      stamp = create(:stamp)
+      expect(stamp).to be_active
+      expect(stamp).not_to be_deactivated
+      stamp.deactivate!
+      expect(stamp).not_to be_active
+      expect(stamp).to be_deactivated
+    end
+
+    context 'when the stamp is already deactivated' do
+      it 'does not alter the deactivated_at time' do
+        time = DateTime.new(2017, 1, 1)
+        stamp = create(:stamp, deactivated_at: time)
+        expect(stamp).to be_deactivated
+        stamp.deactivate!
+        expect(stamp).to be_deactivated
+        expect(stamp.deactivated_at).to eq(time)
+      end
+    end
+      
+  end
 end

--- a/spec/models/stamp_spec.rb
+++ b/spec/models/stamp_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Stamp, type: :model do
   describe '#destroy' do
     before do
       @stamp = create(:stamp)
-      @perm = @stamp.permissions.create(permission_type: :spend, permitted: 'jeff')
+      @perm = @stamp.permissions.create(permission_type: :consume, permitted: 'jeff')
       @mat = create(:stamp_material, stamp: @stamp)
 
       @stamp.destroy!

--- a/spec/requests/api/v1/materials_spec.rb
+++ b/spec/requests/api/v1/materials_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe 'api/v1/materials', type: :request do
   before do
     @stamps = create_list(:stamp, 2, owner_id: owner)
     @stamp = @stamps.first
-    @stamp.permissions.create!(permission_type: :spend, permitted: 'pirates')
+    @stamp.permissions.create!(permission_type: :consume, permitted: 'pirates')
     @mat = create(:stamp_material, stamp: @stamp)
 
     request_data = { owner_id: user, materials: [mat_uuid] }

--- a/spec/requests/api/v1/permissions_spec.rb
+++ b/spec/requests/api/v1/permissions_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe 'api/v1/permissions', type: :request do
   before do
     @stamps = create_list(:stamp, 2, owner_id: owner)
     @stamp = @stamps.first
-    @stamp.permissions.create!(permission_type: :spend, permitted: 'pirates')
+    @stamp.permissions.create!(permission_type: :consume, permitted: 'pirates')
     create(:stamp_material, stamp: @stamp)
   end
 
@@ -93,7 +93,7 @@ RSpec.describe 'api/v1/permissions', type: :request do
     let(:postdata) do
       {
         type: 'permissions',
-        attributes: { 'permission-type': :spend, permitted: 'jeff', 'accessible-id': @stamp.id },
+        attributes: { 'permission-type': :consume, permitted: 'jeff', 'accessible-id': @stamp.id },
       }
     end
 
@@ -109,7 +109,7 @@ RSpec.describe 'api/v1/permissions', type: :request do
       it 'should contain a created permission' do
         expect(data[:id]).to be_present
         atr = data[:attributes]
-        expect(atr[:'permission-type'].to_sym).to eq(:spend)
+        expect(atr[:'permission-type'].to_sym).to eq(:consume)
         expect(atr[:permitted]).to eq('jeff')
         expect(atr[:'accessible-id']).to eq(@stamp.id)
       end
@@ -118,7 +118,7 @@ RSpec.describe 'api/v1/permissions', type: :request do
         perm = @stamp.permissions.find { |p| p.id.to_s==data[:id] }
         expect(perm).not_to be_nil
         expect(perm.permitted).to eq('jeff')
-        expect(perm.permission_type.to_sym).to eq(:spend)
+        expect(perm.permission_type.to_sym).to eq(:consume)
         expect(perm.accessible).to eq(@stamp)
       end
 
@@ -169,7 +169,7 @@ RSpec.describe 'api/v1/permissions', type: :request do
     let(:owner) { user }
 
     it 'does not succeed' do
-      putdata = { id: perm_id, type: 'permissions', attributes: { 'permission-type': :write, permitted: 'jeff', 'accessible-id': @stamp.id }}
+      putdata = { id: perm_id, type: 'permissions', attributes: { 'permission-type': :edit, permitted: 'jeff', 'accessible-id': @stamp.id }}
       expect { put api_v1_permission_path(perm_id), params: { data: putdata }.to_json, headers: headers }.to raise_error(ActionController::RoutingError)
       expect(@stamp.permissions.first.reload.permitted).to eq('pirates')
     end
@@ -180,7 +180,7 @@ RSpec.describe 'api/v1/permissions', type: :request do
     let(:owner) { user }
 
     it 'does not succeed' do
-      patchdata = { id: perm_id, type: 'permissions', attributes: { 'permission-type': :write, permitted: 'jeff' }}
+      patchdata = { id: perm_id, type: 'permissions', attributes: { 'permission-type': :edit, permitted: 'jeff' }}
       expect { patch api_v1_permission_path(perm_id), params: { data: patchdata }.to_json, headers: headers }.to raise_error(ActionController::RoutingError)
       expect(@stamp.permissions.first.reload.permitted).to eq('pirates')
     end

--- a/spec/requests/api/v1/stamps_spec.rb
+++ b/spec/requests/api/v1/stamps_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe 'api/v1/stamps', type: :request do
   before do
     @stamps = create_list(:stamp, 3, owner_id: owner)
     @stamp = @stamps.first
-    @stamp.permissions.create!(permission_type: :spend, permitted: 'pirates')
+    @stamp.permissions.create!(permission_type: :consume, permitted: 'pirates')
     create(:stamp_material, stamp: @stamp)
     @stamps[2].deactivate!
     @active_stamps = @stamps[0,2]
@@ -421,9 +421,9 @@ RSpec.describe 'api/v1/stamps', type: :request do
   describe 'POST #set_permissions' do
     let(:permission_data) do
       [
-        { 'permission-type': :spend, permitted: 'jeff' },
-        { 'permission-type': :write, permitted: 'jeff' },
-        { 'permission-type': :spend, permitted: 'dirk' },
+        { 'permission-type': :consume, permitted: 'jeff' },
+        { 'permission-type': :edit, permitted: 'jeff' },
+        { 'permission-type': :consume, permitted: 'dirk' },
       ]
     end
 
@@ -461,7 +461,7 @@ RSpec.describe 'api/v1/stamps', type: :request do
         it { expect(response).to have_http_status(:gone) }
 
         it 'should not update the stamp permissions' do
-          expect(permission_results).to match_array([{'permission-type': :spend, permitted: 'pirates'}])
+          expect(permission_results).to match_array([{'permission-type': :consume, permitted: 'pirates'}])
         end
       end
     end
@@ -471,7 +471,7 @@ RSpec.describe 'api/v1/stamps', type: :request do
       it { expect(response).to have_http_status(:forbidden) }
 
       it 'should not update the stamp permissions' do
-        expect(permission_results).to match_array([{'permission-type': :spend, permitted: 'pirates'}])
+        expect(permission_results).to match_array([{'permission-type': :consume, permitted: 'pirates'}])
       end
 
     end

--- a/spec/requests/api/v1/stamps_spec.rb
+++ b/spec/requests/api/v1/stamps_spec.rb
@@ -29,10 +29,12 @@ RSpec.describe 'api/v1/stamps', type: :request do
   let(:errors) { body[:errors] }
 
   before do
-    @stamps = create_list(:stamp, 2, owner_id: owner)
+    @stamps = create_list(:stamp, 3, owner_id: owner)
     @stamp = @stamps.first
     @stamp.permissions.create!(permission_type: :spend, permitted: 'pirates')
     create(:stamp_material, stamp: @stamp)
+    @stamps[2].deactivate!
+    @active_stamps = @stamps[0,2]
   end
 
   describe 'GET #index' do
@@ -42,32 +44,42 @@ RSpec.describe 'api/v1/stamps', type: :request do
 
     it { expect(response).to have_http_status(:ok) }
 
-    it 'should contain the correct number of stamps' do
-      expect(data.length).to eq(@stamps.length)
+    it 'should contain the correct number of active stamps' do
+      expect(data.length).to eq(@active_stamps.length)
     end
 
-    it 'should have the correct stamp ids' do
-      expect(data.pluck(:id)).to match_array(@stamps.map(&:id))
+    it 'should have the correct active stamp ids' do
+      expect(data.pluck(:id)).to match_array(@active_stamps.map(&:id))
     end
   end
 
   describe 'GET #show' do
-    before do
-      get api_v1_stamp_path(@stamp.id), headers: headers
-    end
+    context 'when the stamp is active' do
+      before do
+        get api_v1_stamp_path(@stamp.id), headers: headers
+      end
 
-    it { expect(response).to have_http_status(:ok) }
+      it { expect(response).to have_http_status(:ok) }
 
-    it 'has the stamp id' do
-      expect(data[:id]).to eq(@stamp.id)
+      it 'has the stamp id' do
+        expect(data[:id]).to eq(@stamp.id)
+      end
+      it 'has the correct attributes' do
+        expect(data[:attributes][:name]).to eq(@stamp.name)
+        expect(data[:attributes][:"owner-id"]).to eq(@stamp.owner_id)
+      end
+      it 'has the correct relationships' do
+        expect(data[:relationships].length).to eq(2)
+        expect(data[:relationships].keys).to match_array([:materials, :permissions])
+      end
     end
-    it 'has the correct attributes' do
-      expect(data[:attributes][:name]).to eq(@stamp.name)
-      expect(data[:attributes][:"owner-id"]).to eq(@stamp.owner_id)
-    end
-    it 'has the correct relationships' do
-      expect(data[:relationships].length).to eq(2)
-      expect(data[:relationships].keys).to match_array([:materials, :permissions])
+    context 'when the stamp is not active' do
+      before do
+        @stamp.deactivate!
+        get api_v1_stamp_path(@stamp.id), headers: headers
+      end
+
+      it { expect(response).to have_http_status(:gone) }
     end
   end
 
@@ -156,6 +168,21 @@ RSpec.describe 'api/v1/stamps', type: :request do
         end
       end
 
+      context 'when the stamp is deactivated' do
+        before do
+          @name = @stamp.name
+          data = { id: @stamp.id, type: 'stamps', attributes: { name: "meringue" } }
+          @stamp.deactivate!
+          put api_v1_stamp_path(@stamp.id), params: { data: data }.to_json, headers: headers
+        end
+
+        it { expect(response).to have_http_status(:gone) }
+
+        it 'does not alter the stamp' do
+          expect(@stamp.name).to eq(@name)
+        end
+      end
+
       context 'when a new owner is specified' do
         before do
           data = { id: @stamp.id, type: 'stamps', attributes: { name: "meringue", 'owner-id': 'jeff' } }
@@ -215,6 +242,21 @@ RSpec.describe 'api/v1/stamps', type: :request do
         end
       end
 
+      context 'when the stamp is deactivated' do
+        before do
+          @name = @stamp.name
+          data = { id: @stamp.id, type: 'stamps', attributes: { name: "meringue" } }
+          @stamp.deactivate!
+          patch api_v1_stamp_path(@stamp.id), params: { data: data }.to_json, headers: headers
+        end
+
+        it { expect(response).to have_http_status(:gone) }
+
+        it 'does not alter the stamp' do
+          expect(@stamp.name).to eq(@name)
+        end
+      end
+
       context 'when a new owner is specified' do
         before do
           data = { id: @stamp.id, type: 'stamps', attributes: { name: "meringue", 'owner-id': 'jeff' } }
@@ -226,6 +268,21 @@ RSpec.describe 'api/v1/stamps', type: :request do
         it 'contains an appropriate error' do
           expect(errors).not_to be_empty
           expect(errors.first[:detail]).to match(/owner[_-]id/)
+        end
+      end
+
+      context 'when the stamp is deactivated' do
+        before do
+          @name = @stamp.name
+          @stamp.deactivate!
+          data = { id: @stamp.id, type: 'stamps', attributes: { name: "meringue" } }
+          patch api_v1_stamp_path(@stamp.id), params: { data: data }.to_json, headers: headers
+        end
+
+        it { expect(response).to have_http_status(:gone) }
+
+        it 'does not update the stamp' do
+          expect(@stamp.reload.name).to eq @name
         end
       end
 
@@ -246,19 +303,35 @@ RSpec.describe 'api/v1/stamps', type: :request do
     end
   end
 
-  describe 'DELETE #destroy' do
+  describe 'DELETE #remove' do
     context 'when I own the stamp' do
       let(:owner) { user }
 
-      before do
-        @stamp_id = @stamps.second.id
-        delete api_v1_stamp_path(@stamp_id), headers: headers
+      context 'when the stamp is active' do
+        before do
+          @stamp_id = @stamps.second.id
+          delete api_v1_stamp_path(@stamp_id), headers: headers
+        end
+
+        it { expect(response).to have_http_status(:no_content) }
+
+        it 'deactivates the model' do
+          expect(Stamp.where(id: @stamp_id).first).to be_deactivated
+        end
       end
 
-      it { expect(response).to have_http_status(:no_content) }
+      context 'when the stamp is already deactivated' do
+        before do
+          @stamps.second.deactivate!
+          @stamp_id = @stamps.second.id
+          delete api_v1_stamp_path(@stamp_id), headers: headers
+        end
 
-      it 'deletes the model' do
-        expect(Stamp.where(id: @stamp_id).first).to be_nil
+        it { expect(response).to have_http_status(:gone) }
+
+        it 'is still deactivated' do
+          expect(Stamp.where(id: @stamp_id).first).to be_deactivated
+        end
       end
     end
 
@@ -270,8 +343,8 @@ RSpec.describe 'api/v1/stamps', type: :request do
 
       it { expect(response).to have_http_status(:forbidden) }
 
-      it 'does not delete the model' do
-        expect(Stamp.where(id: @stamp_id).first).not_to be_nil
+      it 'does not deactivate the model' do
+        expect(Stamp.where(id: @stamp_id).first).to be_active
       end
     end
 
@@ -286,16 +359,8 @@ RSpec.describe 'api/v1/stamps', type: :request do
 
       it { expect(response).to have_http_status(:no_content) }
 
-      it 'deletes the model' do
-        expect(Stamp.where(id: @stamp.id).first).to be_nil
-      end
-
-      it 'deletes the associated permissions' do
-        expect(AkerPermissionGem::Permission.where(id: @perm_id).first).to be_nil
-      end
-
-      it 'deletes the associated materials' do
-        expect(StampMaterial.where(id: @mat_id).first).to be_nil
+      it 'deactivates the model' do
+        expect(Stamp.where(id: @stamp.id).first).to be_deactivated
       end
     end
   end
@@ -362,6 +427,8 @@ RSpec.describe 'api/v1/stamps', type: :request do
       ]
     end
 
+    let(:deactivate) { false }
+
     def permission_results
       @stamp.reload.permissions.map do |p|
         {
@@ -372,6 +439,9 @@ RSpec.describe 'api/v1/stamps', type: :request do
     end
 
     before do
+      if deactivate
+        @stamp.deactivate!
+      end
       post api_v1_stamp_set_permissions_path(@stamp.id), params: { data: permission_data }.to_json, headers: headers
     end
 
@@ -382,6 +452,17 @@ RSpec.describe 'api/v1/stamps', type: :request do
 
       it 'should update the stamp permissions' do
         expect(permission_results).to match_array(permission_data)
+      end
+
+
+      context 'when the stamp is deactivatd' do
+        let(:deactivate) { true }
+        
+        it { expect(response).to have_http_status(:gone) }
+
+        it 'should not update the stamp permissions' do
+          expect(permission_results).to match_array([{'permission-type': :spend, permitted: 'pirates'}])
+        end
       end
     end
 
@@ -395,11 +476,13 @@ RSpec.describe 'api/v1/stamps', type: :request do
 
     end
 
+
   end
 
   describe 'POST #apply' do
     let(:post_materials) { [SecureRandom.uuid] }
     let(:postdata) { { data: { materials: post_materials } } }
+    let(:deactivate) { false }
 
     before do
       request_data = { owner_id: user, materials: post_materials }
@@ -407,6 +490,9 @@ RSpec.describe 'api/v1/stamps', type: :request do
         with(body: request_data.to_json).
         to_return(status: ownership_status)
       @init_materials = @stamp.stamp_materials.map(&:material_uuid)
+      if deactivate
+        @stamp.deactivate!
+      end
       post api_v1_stamp_apply_path(@stamp.id), params: postdata.to_json, headers: headers
     end
 
@@ -419,6 +505,16 @@ RSpec.describe 'api/v1/stamps', type: :request do
 
       it 'should stamp the materials' do
         expect(result_materials).to match_array(@init_materials+post_materials)
+      end
+
+      context 'when the stamp is deactivated' do
+        let(:deactivate) { true }
+
+        it { expect(response).to have_http_status(:gone) }
+
+        it 'should not stamp the materials' do
+          expect(result_materials).to match_array(@init_materials)
+        end
       end
     end
 
@@ -434,6 +530,8 @@ RSpec.describe 'api/v1/stamps', type: :request do
   end
 
   describe 'POST #unapply' do
+    let(:deactivate) { false }
+
     before do
       create(:stamp_material, stamp: @stamp)
       @init_materials = result_materials
@@ -445,6 +543,9 @@ RSpec.describe 'api/v1/stamps', type: :request do
         with(body: request_data.to_json).
         to_return(status: ownership_status)
       postdata = { data: { materials: @post_materials } }
+      if deactivate
+        @stamp.deactivate!
+      end
       post api_v1_stamp_unapply_path(@stamp.id), params: postdata.to_json, headers: headers
     end
 
@@ -459,6 +560,16 @@ RSpec.describe 'api/v1/stamps', type: :request do
 
       it 'should unstamp the materials' do
         expect(result_materials).to match_array(@remaining_materials)
+      end
+
+      context 'when the stamp is deactivated' do
+        let(:deactivate) { true }
+
+        it { expect(response).to have_http_status(:gone) }
+
+        it 'should not unstamp the materials' do
+          expect(result_materials).to match_array(@init_materials)
+        end
       end
     end
 


### PR DESCRIPTION
If you send a DELETE request to a stamp, it gets deactivated
(i.e. stamp.deactivated_at is set to the current time).
If you try and access a deactivated stamp, you get a 410
("gone") status.
Deactivated stamps are filtered out of the index by default.