### PR TITLE
Adds filters to filter on permissions values

### DIFF
--- a/app/resources/api/v1/material_resource.rb
+++ b/app/resources/api/v1/material_resource.rb
@@ -6,6 +6,14 @@ module Api
       filter :material_uuid
       has_one :stamp
 
+      filter :permitted, apply: -> (records, value, _options) {
+        records.joins(:stamp => :permissions).where(stamp: { permissions: { permitted: value}})
+      }
+
+      filter :permission_type, apply: -> (records, value, _options) {
+        records.joins(:stamp => :permissions).where(stamp: { permissions: { permission_type: value}})
+      }      
+
       def self.creatable_fields(context)
         [:material_uuid, :stamp_id]
       end


### PR DESCRIPTION
Adds 2 new filters for materials so we can filter on them by using the permissions table.

For example, this request send to the Stamps service:

/api/v1/materials?filter[permitted]=permissiona@address.co.uk&filter[permission_type]=edit

will find all materials references in the stamp service where the user
permissiona@address.co.uk can edit