### PR TITLE
Converted columns to case insensitive and sanitised

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,9 +20,9 @@ GIT
 
 GIT
   remote: https://github.com/sanger/aker-permission.git
-  revision: 39dead14c5ad4da60271dc2408a3208333b89407
+  revision: 3c8ea05a11a558bb912b84085323990e1192e64b
   specs:
-    aker_permission_gem (0.4.0)
+    aker_permission_gem (0.4.1)
       cancancan
 
 GEM

--- a/app/models/deputy.rb
+++ b/app/models/deputy.rb
@@ -2,4 +2,25 @@ class Deputy < ApplicationRecord
 
   validates :user_email, presence: true, uniqueness: { scope: :deputy }
   validates :deputy, presence: true
+
+  before_validation :sanitise_user, :sanitise_deputy
+  before_save :sanitise_user, :sanitise_deputy
+
+  def sanitise_user
+    if user_email
+      sanitised = user_email.strip.downcase
+      if sanitised != user_email
+        self.user_email = sanitised
+      end
+    end
+  end
+
+  def sanitise_deputy
+    if deputy
+      sanitised = deputy.strip.downcase
+      if sanitised != deputy
+        self.deputy = sanitised
+      end
+    end
+  end
 end

--- a/app/models/stamp.rb
+++ b/app/models/stamp.rb
@@ -8,6 +8,9 @@ class Stamp < ApplicationRecord
 
   validate :validate_name_active_uniqueness, if: :active?
 
+  before_validation :sanitise_name, :sanitise_owner
+  before_save :sanitise_name, :sanitise_owner
+
   def active?
     deactivated_at.nil?
   end
@@ -18,6 +21,24 @@ class Stamp < ApplicationRecord
 
   def deactivate!
     update_attributes!(deactivated_at: DateTime.now) if active?
+  end
+
+  def sanitise_name
+    if name
+      sanitised = name.strip.gsub(/\s+/, ' ')
+      if sanitised != name
+        self.name = sanitised
+      end
+    end
+  end
+
+  def sanitise_owner
+    if owner_id
+      sanitised = owner_id.strip.downcase
+      if sanitised != owner_id
+        self.owner_id = sanitised
+      end
+    end
   end
 
   private

--- a/db/migrate/20171108151443_change_fields_to_case_insensitive.rb
+++ b/db/migrate/20171108151443_change_fields_to_case_insensitive.rb
@@ -1,0 +1,27 @@
+class ChangeFieldsToCaseInsensitive < ActiveRecord::Migration[5.0]
+  def up
+    enable_extension 'citext'
+
+    change_column :deputies, :user_email, :citext, null: false
+    change_column :deputies, :deputy, :citext, null: false
+
+    change_column :permissions, :permitted, :citext
+
+    change_column :stamps, :name, :citext
+    change_column :stamps, :owner_id, :citext
+
+    Deputy.find_each { |d| d.save! if [d.sanitise_user, d.sanitise_deputy].any? } # Non short-circuiting OR
+    AkerPermissionGem::Permission.find_each { |p| p.save! if p.sanitise_permitted }
+    Stamp.find_each { |s| s.save! if [s.sanitise_name, s.sanitise_owner].any? } # Non short-circuiting OR
+  end
+
+  def down
+    change_column :deputies, :user_email, :string, null: true
+    change_column :deputies, :deputy, :string, null: true
+
+    change_column :permissions, :permitted, :string
+
+    change_column :stamps, :name, :string
+    change_column :stamps, :owner_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,15 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171031165540) do
+ActiveRecord::Schema.define(version: 20171108151443) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "uuid-ossp"
+  enable_extension "citext"
 
   create_table "deputies", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
-    t.string   "user_email"
-    t.string   "deputy"
+    t.citext   "user_email", null: false
+    t.citext   "deputy",     null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["deputy"], name: "index_deputies_on_deputy", using: :btree
@@ -26,7 +27,7 @@ ActiveRecord::Schema.define(version: 20171031165540) do
   end
 
   create_table "permissions", force: :cascade do |t|
-    t.string   "permitted",       null: false
+    t.citext   "permitted",       null: false
     t.string   "permission_type", null: false
     t.string   "accessible_type", null: false
     t.uuid     "accessible_id",   null: false
@@ -48,8 +49,8 @@ ActiveRecord::Schema.define(version: 20171031165540) do
   end
 
   create_table "stamps", id: :uuid, default: -> { "uuid_generate_v4()" }, force: :cascade do |t|
-    t.string   "name",           null: false
-    t.string   "owner_id",       null: false
+    t.citext   "name",           null: false
+    t.citext   "owner_id",       null: false
     t.datetime "created_at",     null: false
     t.datetime "updated_at",     null: false
     t.datetime "deactivated_at"

--- a/spec/factories/permissions.rb
+++ b/spec/factories/permissions.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :permission, class: AkerPermissionGem::Permission do
+    permitted "user@sanger.ac.uk"
+    permission_type :spend
+    accessible_type "Stamp"
+  end
+end

--- a/spec/models/deputy_spec.rb
+++ b/spec/models/deputy_spec.rb
@@ -1,5 +1,28 @@
 require 'rails_helper'
 
 RSpec.describe Deputy, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe '#user_email' do
+    it 'should be sanitised' do
+      expect(create(:deputy, user_email: '  ALPHA@BETA  ').user_email).to eq('alpha@beta')
+    end
+  end
+
+  describe '#deputy' do
+    it 'should be sanitised' do
+      expect(create(:deputy, deputy: '  ALPHA@BETA  ').deputy).to eq('alpha@beta')
+    end
+  end
+
+  describe 'validation' do
+    it 'should not be valid unless the sanitised user/deputy combination is unique' do
+      create(:deputy, user_email: 'alpha@omega', deputy: 'beta@omega')
+      expect(build(:deputy, user_email: '  ALPHA@OMEGA  ', deputy: '  BETA@OMEGA  ')).not_to be_valid
+    end
+    it 'should be valid if the sanitised user/deputy combination is unique' do
+      create(:deputy, user_email: 'boss1@omega', deputy: 'dep1@omega')
+      create(:deputy, user_email: 'boss2@omega', deputy: 'dep2@omega')
+      
+      expect(build(:deputy, user_email: '  BOSS1@OMEGA  ', deputy: '  DEP2@OMEGA  ')).to be_valid
+    end
+  end
 end

--- a/spec/models/permission_spec.rb
+++ b/spec/models/permission_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe AkerPermissionGem::Permission, type: :model do
+  let(:stamp) { create(:stamp) }
+  describe '#permission' do
+    it 'should be sanitised' do
+      perm = create(:permission, permitted: '  ALPHA@BETA  ', accessible_id: stamp.id)
+      expect(perm.permitted).to eq('alpha@beta')
+    end
+  end
+end

--- a/spec/models/stamp_spec.rb
+++ b/spec/models/stamp_spec.rb
@@ -2,6 +2,18 @@ require 'rails_helper'
 
 RSpec.describe Stamp, type: :model do
 
+  describe '#name' do
+    it 'should be sanitised' do
+      expect(create(:stamp, name: "  \n  Alpha\t  beta    gamma   \n").name).to eq('Alpha beta gamma')
+    end
+  end
+
+  describe '#owner_id' do
+    it 'should be sanitised' do
+      expect(create(:stamp, owner_id: "   ALPHA@BETA   ").owner_id).to eq('alpha@beta')
+    end
+  end
+
   describe 'validation' do
     context 'when creating a stamp' do
       it 'is not valid without a name' do
@@ -21,6 +33,15 @@ RSpec.describe Stamp, type: :model do
       it 'is not valid with a duplicate name (within the scope of active stamps)' do
         stamp = create(:stamp)
         expect(build(:stamp, name: stamp.name)).not_to be_valid
+      end
+
+      it 'is not valid with a duplicate sanitised name within the scope of active stamps' do
+        create(:stamp, name: 'alpha beta gamma')
+        expect(build(:stamp, name: "  \n  Alpha\t  beta    gamma   \n")).not_to be_valid
+      end
+
+      it 'is valid with a unique sanitised name' do
+        expect(build(:stamp, name: "  \n  Alpha\t  beta    gamma   \n")).to be_valid
       end
     end
 


### PR DESCRIPTION
Deputy:
  user_email and deputy are both citext, both sanitised by downcasing and stripping
Permission:
  permitted is now citext, sanitised by downcasing and stripping
Stamp:
  owner_id is now citext, sanitised by downcasing and stripping
  name is now citext, sanitised by stripping and contracting adjacent whitespace

Uses method p.sanitise_permitted of Permission, defined in AkerPermissionGem version 0.4.1
(updated gem).